### PR TITLE
Added property_pressure, cleaned up code and added simple TLS support…

### DIFF
--- a/homie/device_base.py
+++ b/homie/device_base.py
@@ -273,6 +273,7 @@ class Device_Base(object):
         if connected:
             if self._mqtt_connected is False:
                 self._mqtt_connected = True
+                self.state = "init" # publish init state
                 self.publish_attributes()
                 self.publish_nodes()
                 self.subscribe_topics()

--- a/homie/mqtt/homie_mqtt_client.py
+++ b/homie/mqtt/homie_mqtt_client.py
@@ -17,6 +17,7 @@ MQTT_SETTINGS = {
     "MQTT_KEEPALIVE": 60,
     "MQTT_CLIENT_ID": None,
     "MQTT_SHARE_CLIENT": None,
+    "MQTT_USE_TLS": False,
 }
 
 mqtt_client_count = 0

--- a/homie/mqtt/mqtt_base.py
+++ b/homie/mqtt/mqtt_base.py
@@ -99,7 +99,7 @@ class MQTT_Base(object):
 
     def _on_disconnect(self, rc):
         logger.warning("MQTT On Disconnect: Result Code {}".format(rc))
-        self.connected = False
+        self.mqtt_connected = False
 
     def add_device(self, device):
         self.homie_devices.append(device)

--- a/homie/mqtt/mqtt_base.py
+++ b/homie/mqtt/mqtt_base.py
@@ -99,7 +99,7 @@ class MQTT_Base(object):
 
     def _on_disconnect(self, rc):
         logger.warning("MQTT On Disconnect: Result Code {}".format(rc))
-        self.mqtt_connected(False)
+        self.connected = False
 
     def add_device(self, device):
         self.homie_devices.append(device)

--- a/homie/mqtt/mqtt_base.py
+++ b/homie/mqtt/mqtt_base.py
@@ -17,16 +17,6 @@ import logging
 logger = logging.getLogger(__name__)
 
 
-MQTT_SETTINGS = {
-    "MQTT_BROKER": None,
-    "MQTT_PORT": 1883,
-    "MQTT_USERNAME": None,
-    "MQTT_PASSWORD": None,
-    "MQTT_KEEPALIVE": 60,
-    "MQTT_CLIENT_ID": None,
-    "MQTT_SHARE_CLIENT": False,
-}
-
 
 class MQTT_Base(object):
     def __init__(self, mqtt_settings, last_will):

--- a/homie/mqtt/paho_mqtt_client.py
+++ b/homie/mqtt/paho_mqtt_client.py
@@ -54,6 +54,8 @@ class PAHO_MQTT_Client(MQTT_Base):
                 self.mqtt_settings["MQTT_USERNAME"],
                 password=self.mqtt_settings["MQTT_PASSWORD"],
             )
+        if self.mqtt_settings["MQTT_USE_TLS"]:
+            self.mqtt_client.tls_set()
 
         try:
             self.mqtt_client.connect(
@@ -61,21 +63,11 @@ class PAHO_MQTT_Client(MQTT_Base):
                 port=self.mqtt_settings["MQTT_PORT"],
                 keepalive=self.mqtt_settings["MQTT_KEEPALIVE"],
             )
-
             self.mqtt_client.loop_start()
 
         except Exception as e:
             logger.warning("MQTT Unable to connect to Broker {}".format(e))
 
-        self.mqtt_client.on_connect = self._on_connect
-        self.mqtt_client.on_message = self._on_message
-        self.mqtt_client.on_disconnect = self._on_disconnect
-
-        if self.mqtt_settings["MQTT_USERNAME"]:
-            self.mqtt_client.username_pw_set(
-                self.mqtt_settings["MQTT_USERNAME"],
-                password=self.mqtt_settings["MQTT_PASSWORD"],
-            )
 
         def start():
             try:

--- a/homie/node/property/property_humidity.py
+++ b/homie/node/property/property_humidity.py
@@ -1,7 +1,7 @@
-from .property_integer import Property_Integer
+from .property_float import Property_Float
 
 
-class Property_Humidity(Property_Integer):
+class Property_Humidity(Property_Float):
     def __init__(
         self,
         node,

--- a/homie/node/property/property_pressure.py
+++ b/homie/node/property/property_pressure.py
@@ -1,0 +1,35 @@
+from homie.node.property.property_float import Property_Float
+
+class Property_Pressure(Property_Float):
+    def __init__(
+        self,
+        node,
+        id="pressure",
+        name="Pressure",
+        settable=False,
+        retained=True,
+        qos=1,
+        unit="Pa",
+        data_type=None,
+        data_format=None,
+        value=None,
+        set_value=None,
+        tags=[],
+        meta={},
+    ):
+
+        super().__init__(
+            node,
+            id,
+            name,
+            settable,
+            retained,
+            qos,
+            unit,
+            data_type,
+            data_format,
+            value,
+            set_value,
+            tags,
+            meta,
+        )

--- a/homie/support/repeating_timer.py
+++ b/homie/support/repeating_timer.py
@@ -8,33 +8,24 @@ logger = logging.getLogger(__name__)
 
 
 class Repeating_Timer(object):
-    DEFAULT_INTERVAL_REDUCTION = 0.9
 
     """Repeat `function` every `interval` seconds."""
 
     def __init__(self, interval):
-        self.interval = int(interval * self.DEFAULT_INTERVAL_REDUCTION)
-
-        self.start = time.time()
+        self.interval = float(interval)
         self.event = Event()
-
         self.thread = Thread(target=self._target)
-        self.thread.setDaemon(True)
+        self.thread.daemon = True
         self.thread.start()
-
         self.callbacks = []
 
     def _target(self):
-        while not self.event.wait(self._time):
+        while not self.event.wait(self.interval):
             for callback in self.callbacks:
                 try:
                     callback()
                 except Exception as e:
                     logger.error("Error in timer callback: {}  {}".format(e,traceback.format_exc()))
-
-    @property
-    def _time(self):
-        return self.interval - ((time.time() - self.start) % self.interval)
 
     def add_callback(self, callback):
         self.callbacks.append(callback)


### PR DESCRIPTION
… for system based certificate authorities (e.g. letsencrypt certificates)

My setup has MQTT behind a reverse proxy with TLS support. Having usernames and passwords in the clear with MQTT is not advisable (if this for instance is used across the internet) so simple TLS support can be added at very low cost.
This assumes the system running the code has certificate authority that is recognised, eg. letsencrypt free certificates (or the MQTT server's CA has distributed public certificates).

In addition while i was investigating the issue with connection, i noticed some lines of code in the paho-mqtt-client code were duplicated. Similarily, the location of the MQTT_SETTINGS structure between 2 files, so i have taken the liberty of removing them.

Hopefully this does not break with other changes you're testing.