### PR TITLE
Fix: Send init state

### DIFF
--- a/homie/device_base.py
+++ b/homie/device_base.py
@@ -273,6 +273,7 @@ class Device_Base(object):
         if connected:
             if self._mqtt_connected is False:
                 self._mqtt_connected = True
+                self.state = "init" # publish init state
                 self.publish_attributes()
                 self.publish_nodes()
                 self.subscribe_topics()


### PR DESCRIPTION
init state is not sent yet, because it is assigned in constructor (`__init__`), thus the setter is not called (and it couldn't publish the state yet anyhow)

So, set it again (and hence call the setter that publishes it) directly after MQTT connection has been (re-)established.