### PR TITLE
Allow setting TLS configuration

### DIFF
--- a/homie/mqtt/homie_mqtt_client.py
+++ b/homie/mqtt/homie_mqtt_client.py
@@ -18,6 +18,7 @@ MQTT_SETTINGS = {
     "MQTT_CLIENT_ID": None,
     "MQTT_SHARE_CLIENT": None,
     "MQTT_USE_TLS": False,
+    'MQTT_TLS_OPTIONS' : dict()
 }
 
 mqtt_client_count = 0

--- a/homie/mqtt/paho_mqtt_client.py
+++ b/homie/mqtt/paho_mqtt_client.py
@@ -72,7 +72,7 @@ class PAHO_MQTT_Client(MQTT_Base):
             )
         
         if self.mqtt_settings["MQTT_USE_TLS"]:
-            self.mqtt_client.tls_set()
+            self.mqtt_client.tls_set(**self.mqtt_settings["MQTT_TLS_OPTIONS"])
 
         try:
             self.mqtt_client.connect(


### PR DESCRIPTION
This is a simple solution for setting the TLS configuration in the Paho MQTT client, see issue #29. 