### PR TITLE
get IP and MAC without netifaces

### DIFF
--- a/homie/mqtt/mqtt_base.py
+++ b/homie/mqtt/mqtt_base.py
@@ -8,9 +8,8 @@ Base MQTT Client for a Homie device
 To allow for easy use of different MQTT clients
 
 """
-#from homie.support.network_information import Network_Information
-
-#network_info = Network_Information()
+from homie.support.network_information import Network_Information
+network_info = Network_Information()
 
 import logging
 
@@ -74,18 +73,14 @@ class MQTT_Base(object):
         logger.info("MQTT set will {}, topic {}".format(will, topic))
 
     def get_mac_ip_address(self):
-        '''
         if self.ip_address is None:
             self.ip_address = network_info.get_local_ip(
                 self.mqtt_settings["MQTT_BROKER"], self.mqtt_settings["MQTT_PORT"]
             )
-
         if self.mac_address is None:
-            self.mac_address = network_info.get_local_mac_for_ip(self.ip_address)
+            self.mac_address = network_info.get_local_mac()
 
         return self.mac_address, self.ip_address
-        '''
-        return "NoMAC","NoIP"
 
     def _on_message(self, topic, payload, retain, qos):
         logger.debug(

--- a/homie/support/network_information.py
+++ b/homie/support/network_information.py
@@ -3,6 +3,7 @@
 import logging
 #import netifaces
 import socket
+import uuid
 
 logger = logging.getLogger(__name__)
 
@@ -25,27 +26,28 @@ for i in nics:
 class Network_Information(object):
     """Util for getting a interface' ip to a specific host and the corresponding mac address."""
 
-    def __init__(self):
-        self.ip_to_interface = self.__build_ip_to_interface_dict()
+    # def __init__(self):
+    #     self.ip_to_interface = self.__build_ip_to_interface_dict()
 
-    def __build_ip_to_interface_dict(self):
-        """Build a map of IPv4-Address to Interface-Name (like 'eth0')"""
-        map = {}
-        for interface in netifaces.interfaces():
-            try:
-                ifInfo = netifaces.ifaddresses(interface)[netifaces.AF_INET]
-                for addrInfo in ifInfo:
-                    addr = addrInfo.get("addr")
-                    if addr:
-                        map[addr] = interface
-            except Exception:
-                pass
-        return map
+    # def __build_ip_to_interface_dict(self):
+    #     """Build a map of IPv4-Address to Interface-Name (like 'eth0')"""
+    #     map = {}
+    #     for interface in netifaces.interfaces():
+    #         try:
+    #             ifInfo = netifaces.ifaddresses(interface)[netifaces.AF_INET]
+    #             for addrInfo in ifInfo:
+    #                 addr = addrInfo.get("addr")
+    #                 if addr:
+    #                     map[addr] = interface
+    #         except Exception:
+    #             pass
+    #     return map
 
     def get_local_ip(self, targetHost, targetPort):
         """Gets the local ip to reach the given ip.
         That can be influenced by the system's routing table.
         A socket is opened and closed immediately to achieve that."""
+        ip = "NoIP"
         try:
             s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
             s.connect((targetHost, targetPort))
@@ -57,23 +59,28 @@ class Network_Information(object):
             ip = s.getsockname()[0]
             s.close()
         return ip
-
-    def get_local_mac_for_ip(self, ip):
-        """Get the mac address for that given ip."""
-        logger.debug("Interfaces found: %s", self.ip_to_interface)
-        logger.debug("Looking for IP: %s", ip)
-
-        mac_addr = None
-        if_name = self.ip_to_interface.get(ip)
-
-        try:
-            link = netifaces.ifaddresses(if_name)[netifaces.AF_LINK]
-        except (KeyError, TypeError):
-            logger.warning("Could not determine MAC for: %s", if_name)
-        else:
-            logger.debug("Found link: %s", link)
-            if len(link) > 1:
-                logger.warning("Conflict: Multiple interfaces found for IP: %s!", ip)
-            mac_addr = link[0].get("addr")
+    
+    def get_local_mac(self):
+        _mac = '{:02x}'.format(uuid.getnode())
+        mac_addr = ':'.join([_mac[i:i+2]for i in range(0,12,2)])
         return mac_addr
+
+    # def get_local_mac_for_ip(self, ip):
+    #     """Get the mac address for that given ip."""
+    #     logger.debug("Interfaces found: %s", self.ip_to_interface)
+    #     logger.debug("Looking for IP: %s", ip)
+
+    #     mac_addr = None
+    #     if_name = self.ip_to_interface.get(ip)
+
+    #     try:
+    #         link = netifaces.ifaddresses(if_name)[netifaces.AF_LINK]
+    #     except (KeyError, TypeError):
+    #         logger.warning("Could not determine MAC for: %s", if_name)
+    #     else:
+    #         logger.debug("Found link: %s", link)
+    #         if len(link) > 1:
+    #             logger.warning("Conflict: Multiple interfaces found for IP: %s!", ip)
+    #         mac_addr = link[0].get("addr")
+    #     return mac_addr
 


### PR DESCRIPTION
I was missing the local IP address and the MAC address from my devices. I added some simple lines in the network_information.py and activated them in the mqtt_base.py.

I only need the UUID import for the MAC because the UUID package already provides the address via UUID.getnode() and some formatting.

I just uncomment all netifaces related lines, so the code is not the cleanest but perhaps help full.